### PR TITLE
removing unused getExtensions

### DIFF
--- a/src/MiddlewareListServiceProvider.php
+++ b/src/MiddlewareListServiceProvider.php
@@ -21,9 +21,4 @@ class MiddlewareListServiceProvider implements ServiceProviderInterface
     {
         return new \SplPriorityQueue();
     }
-
-    public function getExtensions()
-    {
-        return [];
-    }
 }


### PR DESCRIPTION
This PR remove the unused method `getExtensions` in `MiddlewareListServiceProvider`